### PR TITLE
Adding support to add Custom TURN server

### DIFF
--- a/moonraker-obico.cfg.sample
+++ b/moonraker-obico.cfg.sample
@@ -33,3 +33,16 @@ level = INFO
 # dest_host = 127.0.0.1
 # dest_port = 80
 # dest_is_ssl = False
+
+# [turn]
+# Enable only if you have own TURN server (eg coturn)
+# server = turn.example.com #your turn server
+# port = 3478 #your turn server listing port
+
+# if your turn server uses use-auth-secret (REST-API Secret Key)
+# secret = secret # your turn server auth secret 
+# username = obico  # <-- Optional for secret, defaults to "obico" if not set
+
+# if your turn server uses lt-cred-mech (Long term credential)
+# username = yourusername # your turn server username 
+# password = yourpassword # your turn server password

--- a/moonraker-obico.cfg.sample
+++ b/moonraker-obico.cfg.sample
@@ -35,14 +35,9 @@ level = INFO
 # dest_is_ssl = False
 
 # [turn]
-# Enable only if you have own TURN server (eg coturn)
-# server = turn.example.com #your turn server
-# port = 3478 #your turn server listing port
-
-# if your turn server uses use-auth-secret (REST-API Secret Key)
-# secret = secret # your turn server auth secret 
-# username = obico  # <-- Optional for secret, defaults to "obico" if not set
-
-# if your turn server uses lt-cred-mech (Long term credential)
-# username = yourusername # your turn server username 
-# password = yourpassword # your turn server password
+# Enable only if you have own TURN server (eg coturn) and know what you are doing
+# moonraker-obico only support lt-cred-mech authentication method
+# server = turn.example.com
+# port = 80
+# username = yourusername
+# password = yourpassword

--- a/moonraker_obico/config.py
+++ b/moonraker_obico/config.py
@@ -280,7 +280,7 @@ class Config:
 
         self.turn = TurnConfig(
             host=config.get('turn', 'server', fallback=config.get('turn', 'host', fallback=None)),
-            port=config.getint('turn', 'port', fallback=3478),
+            port=config.getint('turn', 'port', fallback=80),
             username=config.get('turn', 'username', fallback=None),
             password=config.get('turn', 'password', fallback=None),
         )

--- a/moonraker_obico/config.py
+++ b/moonraker_obico/config.py
@@ -66,10 +66,9 @@ class TunnelConfig:
 @dataclasses.dataclass
 class TurnConfig:
     host: Optional[str] = None
-    port: int = 3478
+    port: int = 80
     username: Optional[str] = None
     password: Optional[str] = None
-    # Secret removed here
 
 
 @dataclasses.dataclass
@@ -284,7 +283,6 @@ class Config:
             port=config.getint('turn', 'port', fallback=3478),
             username=config.get('turn', 'username', fallback=None),
             password=config.get('turn', 'password', fallback=None),
-            # Secret removed
         )
 
         self.webcams = []

--- a/moonraker_obico/config.py
+++ b/moonraker_obico/config.py
@@ -64,6 +64,15 @@ class TunnelConfig:
 
 
 @dataclasses.dataclass
+class TurnConfig:
+    host: Optional[str] = None
+    port: int = 3478
+    username: Optional[str] = None
+    password: Optional[str] = None
+    secret: Optional[str] = None
+
+
+@dataclasses.dataclass
 class WebcamConfig:
 
     def __init__(self, webcam_config_section, is_primary_camera):
@@ -270,6 +279,14 @@ class Config:
             url_blacklist=[],
         )
 
+        self.turn = TurnConfig(
+            host=config.get('turn', 'server', fallback=config.get('turn', 'host', fallback=None)),
+            port=config.getint('turn', 'port', fallback=3478),
+            username=config.get('turn', 'username', fallback=None),
+            password=config.get('turn', 'password', fallback=None),
+            secret=config.get('turn', 'secret', fallback=None),
+        )
+
         self.webcams = []
         webcam_sections = [section for section in config.sections() if section.startswith("webcam")]
         if len(webcam_sections) == 0:
@@ -444,4 +461,3 @@ class Config:
             name_split = sensor.split(' ')
             if len(name_split) > 1 and name_split[0] == 'temperature_sensor' and not name_split[1].startswith('_'):
                 self.moonraker_objects['heater_mapping'][sensor] = name_split[1]
-

--- a/moonraker_obico/config.py
+++ b/moonraker_obico/config.py
@@ -69,7 +69,7 @@ class TurnConfig:
     port: int = 3478
     username: Optional[str] = None
     password: Optional[str] = None
-    secret: Optional[str] = None
+    # Secret removed here
 
 
 @dataclasses.dataclass
@@ -284,7 +284,7 @@ class Config:
             port=config.getint('turn', 'port', fallback=3478),
             username=config.get('turn', 'username', fallback=None),
             password=config.get('turn', 'password', fallback=None),
-            secret=config.get('turn', 'secret', fallback=None),
+            # Secret removed
         )
 
         self.webcams = []

--- a/moonraker_obico/janus_config_builder.py
+++ b/moonraker_obico/janus_config_builder.py
@@ -5,8 +5,6 @@ import os
 import distro
 import subprocess
 import re
-import time
-import base64
 
 from .utils import os_bit, pi_version, board_id
 

--- a/moonraker_obico/janus_config_builder.py
+++ b/moonraker_obico/janus_config_builder.py
@@ -5,6 +5,10 @@ import os
 import distro
 import subprocess
 import re
+import hmac
+import hashlib
+import time
+import base64
 
 from .utils import os_bit, pi_version, board_id
 
@@ -19,6 +23,20 @@ if distro_id == 'raspbian' and pi_version(): # On some Raspbian/RPi OS versions,
 PRECOMPILED_DIR = '{root_dir}/precomplied/{board_id}.{os_id}.{os_version}.{os_bit}'.format(root_dir=JANUS_ROOT_DIR, board_id=board_id(), os_id=distro_id, os_version=distro.major_version(), os_bit=os_bit())
 
 _logger = logging.getLogger('obico.janus_config_builder')
+
+def generate_coturn_credentials(username, secret):
+    """
+    Generates time-limited credentials for Coturn's REST API auth mode (use-auth-secret).
+    """
+    # Create a timestamp valid for 24 hours (86400 seconds)
+    expiry_time = int(time.time()) + 86400 
+    user_combined = "{}:{}".format(expiry_time, username)
+    
+    # Generate HMAC-SHA1 signature using the secret
+    hashed = hmac.new(secret.encode(), user_combined.encode(), hashlib.sha1)
+    password = base64.b64encode(hashed.digest()).decode()
+    
+    return user_combined, password
 
 def janus_jcfg_folders_section(lib_dir):
     return """
@@ -55,7 +73,7 @@ def find_system_janus_paths():
     return (janus_path, janus_lib_path)
 
 
-def build_janus_jcfg(auth_token):
+def build_janus_jcfg(auth_token, turn_config=None):
     janus_jcfg_path = "{etc_dir}/janus.jcfg".format(etc_dir=RUNTIME_JANUS_ETC_DIR)
 
     ld_lib_path = None
@@ -74,6 +92,41 @@ def build_janus_jcfg(auth_token):
     if not janus_bin_path or not folder_section:
         return (None, None)
 
+    # --- TURN CONFIGURATION LOGIC ---
+    
+    # Defaults (Obico Cloud)
+    turn_server = "turn.obico.io"
+    turn_port = 80
+    turn_type = "tcp"
+    turn_user = auth_token
+    turn_pwd = auth_token
+
+    # Check if custom TURN config exists and has a server address
+    if turn_config and turn_config.host:
+        turn_server = turn_config.host
+        turn_port = turn_config.port
+        turn_type = "udp" # Standard TURN servers usually prefer UDP
+        
+        if turn_config.secret:
+            # Case 1: Auth Secret (REST API) - Time Limited Credentials
+            # Used when 'use-auth-secret' is enabled on Coturn
+            # We default to 'obico' as the username base
+            base_username = turn_config.username if turn_config.username else "obico"
+            turn_user, turn_pwd = generate_coturn_credentials(base_username, turn_config.secret)
+            _logger.info(f"Using Custom TURN (REST API Auth): {turn_server}:{turn_port}")
+            
+        elif turn_config.username and turn_config.password:
+            # Case 2: Long-Term Credential (lt-cred-mech) - Static Credentials
+            turn_user = turn_config.username
+            turn_pwd = turn_config.password
+            _logger.info(f"Using Custom TURN (Static Auth): {turn_server}:{turn_port}")
+            
+        else:
+             _logger.warning("Custom TURN server specified but no secret or password provided. Connection may fail.")
+
+    else:
+        _logger.info("Using Default Obico TURN Server")
+
     with open(janus_jcfg_path, 'w') as f:
         f.write("""
 general: {
@@ -85,12 +138,18 @@ general: {
         admin_secret = "janusoverlord"  # String that all Janus requests must contain
 }}
 nat: {{
-        turn_server = "turn.obico.io"
-        turn_port = 80
-        turn_type = "tcp"
-        turn_user = "{auth_token}"
-        turn_pwd = "{auth_token}"
-""".format(auth_token=auth_token))
+        turn_server = "{turn_server}"
+        turn_port = {turn_port}
+        turn_type = "{turn_type}"
+        turn_user = "{turn_user}"
+        turn_pwd = "{turn_pwd}"
+""".format(
+    turn_server=turn_server,
+    turn_port=turn_port,
+    turn_type=turn_type,
+    turn_user=turn_user,
+    turn_pwd=turn_pwd
+))
 
         f.write("""
         ice_ignore_list = "vmnet"
@@ -275,11 +334,11 @@ certificates: {{
 """.format(ws_port=ws_port, admin_ws_port=admin_ws_port))
 
 
-def build_janus_config(webcams, printer_auth_token, ws_port, admin_ws_port):
+def build_janus_config(webcams, printer_auth_token, ws_port, admin_ws_port, turn_config=None):
     if not os.path.exists(RUNTIME_JANUS_ETC_DIR):
         os.makedirs(RUNTIME_JANUS_ETC_DIR)
 
-    (janus_bin_path, ld_lib_path) = build_janus_jcfg(printer_auth_token)
+    (janus_bin_path, ld_lib_path) = build_janus_jcfg(printer_auth_token, turn_config)
     _logger.info('janus_bin_path: {janus_bin_path} - ld_lib_path: {ld_lib_path}'.format(janus_bin_path=janus_bin_path, ld_lib_path=ld_lib_path))
     build_janus_plugin_streaming_jcfg(webcams)
     build_janus_transport_websocket_jcfg(ws_port, admin_ws_port)

--- a/moonraker_obico/webcam_stream.py
+++ b/moonraker_obico/webcam_stream.py
@@ -122,7 +122,14 @@ class WebcamStreamer:
                 data_channel.runtime = dict(stream_id=389, dataport=JANUS_WS_PORT+389) # A random stream_id and port that is unlikely to conflict
                 webcams_to_build_janus_config.append(data_channel)
 
-            (janus_bin_path, ld_lib_path) = build_janus_config(webcams_to_build_janus_config, self.app_config.server.auth_token, JANUS_WS_PORT, JANUS_ADMIN_WS_PORT)
+            (janus_bin_path, ld_lib_path) = build_janus_config(
+                webcams_to_build_janus_config,
+                self.app_config.server.auth_token,
+                JANUS_WS_PORT,
+                JANUS_ADMIN_WS_PORT,
+                self.app_config.turn # Pass the TURN configuration object
+            )
+            
             if not janus_bin_path:
                 raise JanusNotFoundException('Janus not found or not configured correctly. Click the link for troubleshooting guide.')
 


### PR DESCRIPTION
This adds option for configuring self-hosted/custom TURN server for camera stream so it is not limited to P2P webcam stream. 

User can edit TURN server config from moonraker-obico.cfg and will pass the config to janus builder. If config not defined, TURN server will fallback to Obico default. Only support lt-cred-mech.