### PR TITLE
Fall back to nearest precompiled binaries when exact OS version is missing

### DIFF
--- a/moonraker_obico/bin/ffmpeg/run.sh
+++ b/moonraker_obico/bin/ffmpeg/run.sh
@@ -6,7 +6,7 @@ FFMPEG_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 
 . "${FFMPEG_ROOT_DIR}/../utils.sh"
 
-PRECOMPILED_DIR="${FFMPEG_ROOT_DIR}/precomplied/$( debian_variant )"
+PRECOMPILED_DIR="$( precompiled_dir "${FFMPEG_ROOT_DIR}/precomplied" )"
 
 # We need patched ffmpeg for some systems that is distributed with defected ffmpeg, such as h264_v4l2m2m in debian 11 (bullseye, 32-bit)
 if [ -d "${PRECOMPILED_DIR}" ]; then

--- a/moonraker_obico/bin/janus/precomplied/rpi.debian.10.32-bit
+++ b/moonraker_obico/bin/janus/precomplied/rpi.debian.10.32-bit
@@ -1,1 +1,0 @@
-rpi.debian.11.32-bit

--- a/moonraker_obico/bin/janus/precomplied/rpi.debian.13.32-bit
+++ b/moonraker_obico/bin/janus/precomplied/rpi.debian.13.32-bit
@@ -1,1 +1,0 @@
-rpi.debian.12.32-bit

--- a/moonraker_obico/bin/janus/precomplied/rpi.debian.13.64-bit
+++ b/moonraker_obico/bin/janus/precomplied/rpi.debian.13.64-bit
@@ -1,1 +1,0 @@
-rpi.debian.12.64-bit

--- a/moonraker_obico/bin/utils.sh
+++ b/moonraker_obico/bin/utils.sh
@@ -8,6 +8,54 @@ debian_variant() {
   echo $( board_id ).debian.$( debian_release ).$( getconf LONG_BIT )-bit
 }
 
+precompiled_dir() {
+  local root="$1"
+  local exact="${root}/$( debian_variant )"
+  if [ -d "${exact}" ]; then
+    echo "${exact}"
+    return
+  fi
+
+  local current_ver bit board prefix suffix
+  current_ver=$( debian_release )
+  bit=$( getconf LONG_BIT )-bit
+  board=$( board_id )
+  prefix="${board}.debian."
+  suffix=".${bit}"
+
+  local best_le_ver=-1 best_le_dir=""
+  local best_gt_ver=-1 best_gt_dir=""
+  local d name ver
+  if [ -d "${root}" ]; then
+    for d in "${root}"/${prefix}*${suffix}; do
+      [ -d "$d" ] || continue
+      name="${d##*/}"
+      ver="${name#${prefix}}"
+      ver="${ver%${suffix}}"
+      case "$ver" in
+        ''|*[!0-9]*) continue;;
+      esac
+      if [ "$ver" -le "$current_ver" ]; then
+        if [ "$ver" -gt "$best_le_ver" ]; then
+          best_le_ver="$ver"; best_le_dir="$d"
+        fi
+      else
+        if [ "$best_gt_ver" -lt 0 ] || [ "$ver" -lt "$best_gt_ver" ]; then
+          best_gt_ver="$ver"; best_gt_dir="$d"
+        fi
+      fi
+    done
+  fi
+
+  if [ -n "${best_le_dir}" ]; then
+    echo "${best_le_dir}"
+  elif [ -n "${best_gt_dir}" ]; then
+    echo "${best_gt_dir}"
+  else
+    echo "${exact}"
+  fi
+}
+
 board_id() {
     local model_file="/sys/firmware/devicetree/base/model"
 

--- a/moonraker_obico/janus_config_builder.py
+++ b/moonraker_obico/janus_config_builder.py
@@ -16,9 +16,52 @@ distro_id = distro.id()
 if distro_id == 'raspbian' and pi_version(): # On some Raspbian/RPi OS versions, distro.id() returns 'debian'. On others, it returns 'raspbian'.
     distro_id = 'debian'
 
-PRECOMPILED_DIR = '{root_dir}/precomplied/{board_id}.{os_id}.{os_version}.{os_bit}'.format(root_dir=JANUS_ROOT_DIR, board_id=board_id(), os_id=distro_id, os_version=distro.major_version(), os_bit=os_bit())
-
 _logger = logging.getLogger('obico.janus_config_builder')
+
+
+def find_precompiled_dir():
+    precomplied_root = os.path.join(JANUS_ROOT_DIR, 'precomplied')
+    requested_variant = '{board_id}.{os_id}.{os_version}.{os_bit}'.format(
+        board_id=board_id(), os_id=distro_id, os_version=distro.major_version(), os_bit=os_bit())
+    exact_dir = os.path.join(precomplied_root, requested_variant)
+
+    if os.path.isdir(exact_dir):
+        return exact_dir, requested_variant, requested_variant
+
+    try:
+        current_version = int(distro.major_version())
+    except (ValueError, TypeError):
+        return exact_dir, requested_variant, None
+
+    if not os.path.isdir(precomplied_root):
+        return exact_dir, requested_variant, None
+
+    pattern = re.compile(r'^' + re.escape('{}.{}.'.format(board_id(), distro_id)) + r'(\d+)' + re.escape('.' + os_bit()) + r'$')
+    older_or_eq = []
+    newer = []
+    for entry in os.listdir(precomplied_root):
+        m = pattern.match(entry)
+        if m:
+            ver = int(m.group(1))
+            if ver <= current_version:
+                older_or_eq.append((ver, entry))
+            else:
+                newer.append((ver, entry))
+
+    if older_or_eq:
+        older_or_eq.sort(reverse=True)
+        chosen_variant = older_or_eq[0][1]
+    elif newer:
+        newer.sort()
+        chosen_variant = newer[0][1]
+    else:
+        return exact_dir, requested_variant, None
+
+    _logger.warning('No exact precompiled match for %s; falling back to %s', requested_variant, chosen_variant)
+    return os.path.join(precomplied_root, chosen_variant), requested_variant, chosen_variant
+
+
+PRECOMPILED_DIR, REQUESTED_PRECOMPILED_VARIANT, CHOSEN_PRECOMPILED_VARIANT = find_precompiled_dir()
 
 def janus_jcfg_folders_section(lib_dir):
     return """
@@ -278,6 +321,14 @@ certificates: {{
 def build_janus_config(webcams, printer_auth_token, ws_port, admin_ws_port):
     if not os.path.exists(RUNTIME_JANUS_ETC_DIR):
         os.makedirs(RUNTIME_JANUS_ETC_DIR)
+
+    if CHOSEN_PRECOMPILED_VARIANT and CHOSEN_PRECOMPILED_VARIANT != REQUESTED_PRECOMPILED_VARIANT:
+        try:
+            import sentry_sdk
+            sentry_sdk.set_tag('janus_requested_variant', REQUESTED_PRECOMPILED_VARIANT)
+            sentry_sdk.set_tag('janus_precompiled_variant', CHOSEN_PRECOMPILED_VARIANT)
+        except Exception:
+            pass
 
     (janus_bin_path, ld_lib_path) = build_janus_jcfg(printer_auth_token)
     _logger.info('janus_bin_path: {janus_bin_path} - ld_lib_path: {ld_lib_path}'.format(janus_bin_path=janus_bin_path, ld_lib_path=ld_lib_path))


### PR DESCRIPTION
## Summary
- Adds version-aware fallback in `janus_config_builder.find_precompiled_dir` (Python) and `bin/utils.sh::precompiled_dir` (shell): when no exact precompiled directory matches the running OS, prefer the highest available version <= current; if none exist, fall back upward to the lowest > current.
- Tags `janus_requested_variant` and `janus_precompiled_variant` into Sentry when the fallback engages.
- Wires `bin/ffmpeg/run.sh` through the new helper so future precompiled ffmpeg binaries get the same fallback treatment.
- Removes redundant symlinks `rpi.debian.10.32-bit -> rpi.debian.11.32-bit`, `rpi.debian.13.32-bit -> rpi.debian.12.32-bit`, and `rpi.debian.13.64-bit -> rpi.debian.12.64-bit`. The new fallback routes those Debian versions to the appropriate binaries automatically.

Mirrors the OctoPrint-Obico fix [TheSpaghettiDetective/OctoPrint-Obico#246](https://github.com/TheSpaghettiDetective/OctoPrint-Obico/pull/246).

## Why
Symlinks worked here because moonraker-obico installs via `git clone` (preserves symlinks), but every new Debian release required adding a symlink in the repo. Code-level fallback handles future Debian releases (14, 15, ...) without further repo changes, and also covers any board/version combination that did not have a symlink.

## Verification
- **Python + bash sanity tests** (run from repo root): both helpers route `Deb 13/14 -> Deb 12`, `Deb 10 -> Deb 11` (post-dedup), preserve exact matches for Deb 11/12, fall upward when no <= candidate exists. `mks` board correctly stays within `mks.debian.*` directories.
- **Docker on real Debian 13** (`debian:trixie-slim`, both `linux/arm64` and `linux/arm/v7`, done in the OctoPrint-Obico PR): the Debian 12 Janus binaries (byte-identical to those in this repo) load and execute `janus --version` cleanly against glibc 2.41 with bundled `LD_LIBRARY_PATH` plus `libssl3 libcurl4 zlib1g libglib2.0-0t64`.

## Test plan
- [ ] Verify a Debian 12 install (RPi or otherwise) continues to use the exact-match `rpi.debian.12.<bit>` directory with no fallback warning logged.
- [ ] Verify a Debian 13 install logs `No exact precompiled match for rpi.debian.13.<bit>; falling back to rpi.debian.12.<bit>` and webcam streaming works.
- [ ] Verify a Debian 10 32-bit install logs `... falling back to rpi.debian.11.32-bit` and webcam streaming works (the symlink that previously routed it is now gone).