### PR TITLE
Use the TURN server configured on obico-server

### DIFF
--- a/moonraker_obico/app.py
+++ b/moonraker_obico/app.py
@@ -20,6 +20,7 @@ from .version import VERSION
 from .utils import SentryWrapper, run_in_thread
 from .webcam_capture import JpegPoster
 from .webcam_stream import WebcamStreamer
+from .janus_config_builder import turn_credential_expiry_warning, printer_info_for_log, TURN_DOCS_URL
 from .logger import setup_logging
 from .printer import PrinterState
 from .config import MoonrakerConfig, ServerConfig, Config
@@ -110,7 +111,7 @@ class App(object):
 
         # Blocking call. When continued, server is guaranteed to be properly configured, self.model.linked_printer existed.
         linked_printer = self.wait_for_auth_token(config)
-        _logger.info('Linked printer: {}'.format(linked_printer))
+        _logger.info('Linked printer: {}'.format(printer_info_for_log(linked_printer)))
 
         self.model = App.Model(
             config=config,
@@ -165,6 +166,7 @@ class App(object):
 
         run_in_thread(self.jpeg_poster.pic_post_loop)
         run_in_thread(self.status_update_to_client_loop)
+        run_in_thread(self.turn_credential_expiry_loop)
 
         even_loop_thread = run_in_thread(self.event_loop)
 
@@ -437,6 +439,21 @@ class App(object):
         else:
             _logger.warning('Not linked or not connected to server. Ignoring re-linking request.')
 
+
+    def turn_credential_expiry_loop(self):
+        warned = set()
+        while self.shutdown is False:
+            try:
+                warning = turn_credential_expiry_warning(self.model.linked_printer.get('turn'), 'Obico for Klipper')
+                if warning:
+                    (title, text) = warning
+                    _logger.warning(text)
+                    if title not in warned:
+                        warned.add(title)
+                        self.server_conn.post_printer_event_to_server(title, text, event_class='WARNING', info_url=TURN_DOCS_URL)
+            except Exception:
+                self.sentry.captureException()
+            time.sleep(3600)
 
     def status_update_to_client_loop(self):
         while self.shutdown is False:

--- a/moonraker_obico/janus_config_builder.py
+++ b/moonraker_obico/janus_config_builder.py
@@ -1,5 +1,6 @@
 import sys
 import logging
+import time
 import json
 import os
 import distro
@@ -98,7 +99,80 @@ def find_system_janus_paths():
     return (janus_path, janus_lib_path)
 
 
-def build_janus_jcfg(auth_token):
+DEFAULT_TURN = dict(server='turn.obico.io', port=80, transport='tcp')  # Obico Cloud. Authenticates with the printer's auth token.
+
+
+def turn_settings(auth_token, turn=None):
+    """
+    (server, port, transport, username, credential) for the Janus nat section.
+
+    `turn` is the TURN configuration the server sent as part of the linked printer info. When the server
+    didn't send one, or it isn't usable, fall back to the Obico Cloud TURN server.
+    """
+    if turn:
+        try:
+            server = str(turn['server']).strip()
+            username = str(turn['username'])
+            credential = str(turn['credential'])
+            port = int(turn.get('port') or 3478)
+            transports = [str(t).strip().lower() for t in (turn.get('transports') or [])]
+            transport = transports[0] if transports else 'udp'
+            usable = (
+                server and username and credential
+                and 0 < port < 65536
+                and transport in ('udp', 'tcp')
+                and not any(c in v for v in (server, username, credential) for c in '"\r\n')
+            )
+        except (KeyError, TypeError, ValueError, AttributeError):
+            usable = False
+
+        if usable:
+            return (server, port, transport, username, credential)
+        _logger.warning('Ignoring unusable TURN config from the server. Using the default TURN server.')
+
+    return (DEFAULT_TURN['server'], DEFAULT_TURN['port'], DEFAULT_TURN['transport'], auth_token, auth_token)
+
+
+def printer_info_for_log(linked_printer):
+    """linked_printer with the TURN credential masked, for logging."""
+    turn = (linked_printer or {}).get('turn')
+    if isinstance(turn, dict) and turn.get('credential'):
+        return dict(linked_printer, turn=dict(turn, credential='<redacted>'))
+    return linked_printer
+
+
+TURN_EXPIRY_WARNING_SECONDS = 30 * 24 * 3600
+TURN_DOCS_URL = 'https://www.obico.io/docs/server-guides/advanced/webcam-turn-server/'
+
+
+def turn_credential_expiry_warning(turn, agent_name):
+    """
+    (title, text) of a warning when the TURN credential from the server expires soon or has expired. None otherwise.
+
+    The credential is fetched at startup and can't be renewed while running, so the fix is always a restart.
+    """
+    try:
+        expires_at = int((turn or {}).get('expires_at') or 0)
+    except (TypeError, ValueError):
+        return None
+    if not expires_at:
+        return None
+
+    remaining = expires_at - time.time()
+    if remaining > TURN_EXPIRY_WARNING_SECONDS:
+        return None
+    if remaining > 0:
+        return (
+            'Webcam streaming credential expires soon',
+            'The TURN credential for webcam streaming expires in {} days. Restart {} to get a new one.'.format(int(remaining // 86400), agent_name),
+        )
+    return (
+        'Webcam streaming credential expired',
+        'The TURN credential for webcam streaming has expired. Webcam streaming from outside your network will fail until you restart {}.'.format(agent_name),
+    )
+
+
+def build_janus_jcfg(auth_token, turn=None):
     janus_jcfg_path = "{etc_dir}/janus.jcfg".format(etc_dir=RUNTIME_JANUS_ETC_DIR)
 
     ld_lib_path = None
@@ -117,6 +191,9 @@ def build_janus_jcfg(auth_token):
     if not janus_bin_path or not folder_section:
         return (None, None)
 
+    (turn_server, turn_port, turn_type, turn_user, turn_pwd) = turn_settings(auth_token, turn)
+    _logger.info('Janus TURN server: {}:{} ({})'.format(turn_server, turn_port, turn_type))
+
     with open(janus_jcfg_path, 'w') as f:
         f.write("""
 general: {
@@ -128,12 +205,12 @@ general: {
         admin_secret = "janusoverlord"  # String that all Janus requests must contain
 }}
 nat: {{
-        turn_server = "turn.obico.io"
-        turn_port = 80
-        turn_type = "tcp"
-        turn_user = "{auth_token}"
-        turn_pwd = "{auth_token}"
-""".format(auth_token=auth_token))
+        turn_server = "{turn_server}"
+        turn_port = {turn_port}
+        turn_type = "{turn_type}"
+        turn_user = "{turn_user}"
+        turn_pwd = "{turn_pwd}"
+""".format(turn_server=turn_server, turn_port=turn_port, turn_type=turn_type, turn_user=turn_user, turn_pwd=turn_pwd))
 
         f.write("""
         ice_ignore_list = "vmnet"
@@ -318,7 +395,7 @@ certificates: {{
 """.format(ws_port=ws_port, admin_ws_port=admin_ws_port))
 
 
-def build_janus_config(webcams, printer_auth_token, ws_port, admin_ws_port):
+def build_janus_config(webcams, printer_auth_token, ws_port, admin_ws_port, turn=None):
     if not os.path.exists(RUNTIME_JANUS_ETC_DIR):
         os.makedirs(RUNTIME_JANUS_ETC_DIR)
 
@@ -330,7 +407,7 @@ def build_janus_config(webcams, printer_auth_token, ws_port, admin_ws_port):
         except Exception:
             pass
 
-    (janus_bin_path, ld_lib_path) = build_janus_jcfg(printer_auth_token)
+    (janus_bin_path, ld_lib_path) = build_janus_jcfg(printer_auth_token, turn)
     _logger.info('janus_bin_path: {janus_bin_path} - ld_lib_path: {ld_lib_path}'.format(janus_bin_path=janus_bin_path, ld_lib_path=ld_lib_path))
     build_janus_plugin_streaming_jcfg(webcams)
     build_janus_transport_websocket_jcfg(ws_port, admin_ws_port)

--- a/moonraker_obico/webcam_stream.py
+++ b/moonraker_obico/webcam_stream.py
@@ -96,6 +96,7 @@ class WebcamStreamer:
         self.printer_state = app_model.printer_state
         self.app_config = app_model.config
         self.is_pro = app_model.linked_printer.get('is_pro')
+        self.linked_printer = app_model.linked_printer
         self.sentry = sentry
         self.ffmpeg_out_rtp_ports = set()
         self.mjpeg_sock_list = []
@@ -125,7 +126,7 @@ class WebcamStreamer:
                 data_channel.runtime = dict(stream_id=389, dataport=JANUS_WS_PORT+389) # A random stream_id and port that is unlikely to conflict
                 webcams_to_build_janus_config.append(data_channel)
 
-            (janus_bin_path, ld_lib_path) = build_janus_config(webcams_to_build_janus_config, self.app_config.server.auth_token, JANUS_WS_PORT, JANUS_ADMIN_WS_PORT)
+            (janus_bin_path, ld_lib_path) = build_janus_config(webcams_to_build_janus_config, self.app_config.server.auth_token, JANUS_WS_PORT, JANUS_ADMIN_WS_PORT, turn=self.linked_printer.get('turn'))
             if not janus_bin_path:
                 raise JanusNotFoundException('Janus not found or not configured correctly. Click the link for troubleshooting guide.')
 


### PR DESCRIPTION
Closes #129. Agent side of the plan agreed there; server side is TheSpaghettiDetective/obico-server#1157. Same change for OctoPrint-Obico: TheSpaghettiDetective/OctoPrint-Obico#248.

## What changed

`GET /api/v1/octo/printer/` (already fetched at startup as `linked_printer`) can now include a `turn` object. `build_janus_jcfg()` writes it into the `nat` section of `janus.jcfg` instead of the hard-coded `turn.obico.io` block. Nothing to configure on the printer.

`turn_settings()` validates what the server sent (server, port, transport, username, credential; no quotes or newlines since it goes into the jcfg). Anything missing or unusable falls back to the current `turn.obico.io` + auth token block with one warning in the log, so an old server, or a server without TURN configured, behaves exactly as today. Startup logs which TURN server Janus is using.

In shared-secret mode the server issues credentials that expire (default one year). The agent fetches its credential once at startup and can't renew it, so a new hourly check logs a warning and posts a printer event once when the credential is within 30 days of expiry, and again if it has expired. Both say to restart the agent. In static-credential mode `expires_at` is null and nothing fires. The one year expiry was chosen since the agent currently has no reliable "restart" mechanic that would reliably produce rotation. I figured that agent restarts, power losses, etc would happen more frequently than the year credential lease - acting as a natural protection for expiry. However, future work could focus on an automated approach if anybody runs a system with more than 1 year uptime.

The startup "Linked printer" log line now masks the TURN credential, since the server response contains one.

`janus_config_builder.py` stays a copy of the OctoPrint-Obico one; the new code is identical in both, keeping both repos up to date.

## Testing

Ran `build_janus_jcfg()` against a temp jcfg for all types of bad inputs. All bad inputs correctly fallback to produce today's behavior. Expiry helper checked for none / static / far / soon / expired / garbage. End-to-end on my self-hosted stack: obico-server branch + coturn in `use-auth-secret` (more secure) mode + the moonraker-obico branch on the printer. The server minted a `<expiry>:printer-1` credential, the agent wrote it into `janus.jcfg`, and the coturn log shows `ALLOCATE processed, success` for that username, `CREATE_PERMISSION processed, success`, and non-zero relay usage. Webcam stream verified working from a phone on mobile data. Testing also produced some useful docs refinements in TheSpaghettiDetective/obico-server#1157.